### PR TITLE
Parser improvements

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,7 +1,7 @@
 (executable
  (name parser_bench)
  (modules parser_bench)
- (libraries core_bench core_unix.command_unix async_http))
+ (libraries core_bench core_unix.command_unix async_http memtrace))
 
 (executable
  (name server_bench)

--- a/bench/dune
+++ b/bench/dune
@@ -8,4 +8,4 @@
  (modules server_bench)
  (preprocess
   (pps ppx_jane))
- (libraries core core_unix.command_unix async async_http))
+ (libraries core core_unix.command_unix async async_http memtrace))

--- a/bench/parser_bench.ml
+++ b/bench/parser_bench.ml
@@ -41,4 +41,7 @@ let tests =
   ]
 ;;
 
-let () = Command_unix.run (Bench.make_command tests)
+let () =
+  Memtrace.trace_if_requested ();
+  Command_unix.run (Bench.make_command tests)
+;;

--- a/bench/server_bench.ml
+++ b/bench/server_bench.ml
@@ -54,4 +54,7 @@ let command =
         Tcp.Server.close_finished_and_handlers_determined server)
 ;;
 
-let () = Command_unix.run command
+let () =
+  Memtrace.trace_if_requested ();
+  Command_unix.run command
+;;

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -161,65 +161,42 @@ let invalid_method = Fail (Error.of_string "Invalid Method")
 let meth source =
   let pos = Source.index source ' ' in
   if pos = -1 then raise_notrace Partial;
-  let ( = ) = Char.( = ) in
   let meth =
     match pos with
     | 3 ->
-      if source.![0] = 'G' && source.![1] = 'E' && source.![2] = 'T'
-      then `GET
-      else if source.![0] = 'P' && source.![1] = 'U' && source.![3] = 'T'
-      then `PUT
-      else raise_notrace invalid_method
+      (match source.![0], source.![1], source.![2] with
+      | 'G', 'E', 'T' -> `GET
+      | 'P', 'U', 'T' -> `PUT
+      | _ -> raise_notrace invalid_method)
     | 4 ->
-      if source.![0] = 'H' && source.![1] = 'E' && source.![2] = 'A' && source.![3] = 'D'
-      then `HEAD
-      else if source.![0] = 'P'
-              && source.![1] = 'O'
-              && source.![2] = 'S'
-              && source.![3] = 'T'
-      then `POST
-      else raise_notrace invalid_method
+      (match source.![0], source.![1], source.![2], source.![3] with
+      | 'H', 'E', 'A', 'D' -> `HEAD
+      | 'P', 'O', 'S', 'T' -> `POST
+      | _ -> raise_notrace invalid_method)
     | 5 ->
-      if source.![0] = 'P'
-         && source.![1] = 'A'
-         && source.![2] = 'T'
-         && source.![3] = 'C'
-         && source.![4] = 'H'
-      then `PATCH
-      else if source.![0] = 'T'
-              && source.![1] = 'R'
-              && source.![2] = 'A'
-              && source.![3] = 'C'
-              && source.![4] = 'E'
-      then `TRACE
-      else raise_notrace invalid_method
+      (match source.![0], source.![1], source.![2], source.![3], source.![4] with
+      | 'P', 'A', 'T', 'C', 'H' -> `PATCH
+      | 'T', 'R', 'A', 'C', 'E' -> `TRACE
+      | _ -> raise_notrace invalid_method)
     | 6 ->
-      if source.![0] = 'D'
-         && source.![1] = 'E'
-         && source.![2] = 'L'
-         && source.![3] = 'E'
-         && source.![4] = 'T'
-         && source.![5] = 'E'
-      then `DELETE
-      else raise_notrace invalid_method
+      (match
+         source.![0], source.![1], source.![2], source.![3], source.![4], source.![5]
+       with
+      | 'D', 'E', 'L', 'E', 'T', 'E' -> `DELETE
+      | _ -> raise_notrace invalid_method)
     | 7 ->
-      if source.![0] = 'C'
-         && source.![1] = 'O'
-         && source.![2] = 'N'
-         && source.![3] = 'N'
-         && source.![4] = 'E'
-         && source.![5] = 'C'
-         && source.![6] = 'T'
-      then `CONNECT
-      else if source.![0] = 'O'
-              && source.![1] = 'P'
-              && source.![2] = 'T'
-              && source.![3] = 'I'
-              && source.![4] = 'O'
-              && source.![5] = 'N'
-              && source.![6] = 'S'
-      then `OPTIONS
-      else raise_notrace invalid_method
+      (match
+         ( source.![0]
+         , source.![1]
+         , source.![2]
+         , source.![3]
+         , source.![4]
+         , source.![4]
+         , source.![6] )
+       with
+      | 'C', 'O', 'N', 'N', 'E', 'C', 'T' -> `CONNECT
+      | 'O', 'P', 'T', 'I', 'O', 'N', 'S' -> `OPTIONS
+      | _ -> raise_notrace invalid_method)
     | _ -> raise_notrace invalid_method
   in
   Source.advance_unsafe source (pos + 1);

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -191,7 +191,7 @@ let meth source =
          , source.![2]
          , source.![3]
          , source.![4]
-         , source.![4]
+         , source.![5]
          , source.![6] )
        with
       | 'C', 'O', 'N', 'N', 'E', 'C', 'T' -> `CONNECT
@@ -399,3 +399,7 @@ let run_parser ?pos ?len buf p =
 let parse_request ?pos ?len buf = run_parser ?pos ?len buf request
 let parse_chunk_length ?pos ?len buf = run_parser ?pos ?len buf chunk_length
 let parse_chunk ?pos ?len buf chunk_kind = run_parser ?pos ?len buf (chunk chunk_kind)
+
+module Private = struct
+  let parse_method payload = run_parser (Bigstring.of_string payload) meth
+end

--- a/src/parser.mli
+++ b/src/parser.mli
@@ -26,3 +26,7 @@ val parse_chunk
   -> Bigstring.t
   -> chunk_kind
   -> (chunk_parser_result * int, error) result
+
+module Private : sig
+  val parse_method : string -> (Meth.t * int, error) result
+end

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -126,7 +126,7 @@ let%expect_test "can validate http version" =
   in
   print_s
     ([%sexp_of: Request.t success Or_error.t] (parse_or_error (P.parse_request req)));
-  [%expect {| (Error ("Parse error" ("Invalid http version" 4))) |}]
+  [%expect {| (Error ("Parse error" "Invalid HTTP Version")) |}]
 ;;
 
 let%expect_test "parse result indicates location of start of body" =


### PR DESCRIPTION
A few improvements to the HTTP parser. The core_bench output for the main branch:
```
  Name                    Time/Run   mWd/Run   Percentage
 ----------------------- ---------- --------- ------------
  H1 (httparse example)   587.07ns   206.00w      100.00%
  Parse chunk size         33.30ns     9.00w        5.67%
  Parse hex number         31.29ns     6.00w        5.33%
```

Core_bench output for this pull-request

```
  Name                    Time/Run   mWd/Run   Percentage
 ----------------------- ---------- --------- ------------
  H1 (httparse example)   512.77ns   177.00w      100.00%
  Parse chunk size         33.83ns     9.00w        6.60%
  Parse hex number         31.08ns     6.00w        6.06%
```